### PR TITLE
Write missing index.html for spec number path

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,12 @@ module.exports = {
           files.map(function(file) {
             if (file.match(/README\.md$/) == null && fs.lstatSync(file).isFile()) {
               var content = fs.readFileSync(file);
+
+              // write `_book/spec:NN/index.html` file
               fs.writeFileSync("_book/spec:" + file.replace(new RegExp("^" + n), n + "/" + name), content);
+
+              // write `_book/NN/index.html` file
+              fs.writeFileSync("_book/" + file.replace(new RegExp("^" + n), n + "/" + name), content);
             }
           });
         }


### PR DESCRIPTION
This changeset proposes a fix for unprotocols/gitbook-plugin-coss#6, wherein the file `index.html` is not getting written for the path `NN/`, where `NN` is the number for a spec (similar to `/spec:NN`, which _does_ get written correctly).